### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/beancount.py
+++ b/beancount.py
@@ -12,7 +12,7 @@ import glob
 import json
 from datetime import datetime
 from pypinyin import lazy_pinyin
-from fuzzywuzzy import fuzz, process
+from rapidfuzz import fuzz, process
 
 
 class Beancount:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-fuzzywuzzy==0.18.0
+rapidfuzz==0.3.0
 prompt_toolkit==2.0.10
 pypinyin==0.37.0
-python-Levenshtein==0.12.0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy